### PR TITLE
Update Examples API and Session pages to match pyhiveapi 0.5.15

### DIFF
--- a/docs/examples/api.md
+++ b/docs/examples/api.md
@@ -15,7 +15,7 @@ and get a session token.
 import pyhiveapi as Hive
 
 tokens = {}
-hive_auth = Hive.Auth("<Hive Username>", "<Hive Password>")
+hive_auth = Hive.Auth(username="<Hive Username>", password="<Hive Password>")
 authData = hive_auth.login()
 
 if authData.get("ChallengeName") == "SMS_MFA":
@@ -41,10 +41,10 @@ import pyhiveapi as Hive
 
 tokens = {}
 hive_auth = Hive.Auth(<Hive Username>", "<Hive Password>", "Hive Device Group Key>", "<Hive Device Key>", "<Hive Device Password>")
-authData = hive_auth.deviceLogin()
+auth_data = hive_auth.device_login()
 
-if "AuthenticationResult" in authData:
-    session = authData["AuthenticationResult"]
+if "AuthenticationResult" in auth_data:
+    session = auth_data["AuthenticationResult"]
     tokens.update({"token": session["IdToken"]})
     tokens.update({"refreshToken": session["RefreshToken"]})
     tokens.update({"accessToken": session["AccessToken"]})
@@ -62,11 +62,11 @@ import pyhiveapi as Hive
 
 tokens = {}
 hive_auth = Hive.Auth(<Hive Username>", "<Hive Password>", "Hive Device Group Key>", "<Hive Device Key>", "<Hive Device Password>")
-authData = hive_auth.deviceLogin()
-newTokens = hive_auth.refreshToken(tokens['AuthenticationResult']['RefreshToken'])
+auth_data = hive_auth.device_login()
+new_tokens = hive_auth.refresh_token(tokens['AuthenticationResult']['RefreshToken'])
 
-if "AuthenticationResult" in newTokens:
-    session = newTokens["AuthenticationResult"]
+if "AuthenticationResult" in new_tokens:
+    session = new_tokens["AuthenticationResult"]
     tokens.update({"token": session["IdToken"]})
     tokens.update({"refreshToken": session["RefreshToken"]})
     tokens.update({"accessToken": session["AccessToken"]})
@@ -78,6 +78,6 @@ Below is an example how to data from the Hive platform
 using the session token acquired from login.
 
 ```Python
-api = Hive.HiveApi(token=tokens["IdToken"])
+api = Hive.API(token=tokens["IdToken"])
 data = api.getAll()
 ```

--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -22,7 +22,7 @@ if login.get("ChallengeName") == SMS_REQUIRED:
     session.sms2fa(code, login)
 
 # Device data is need for future device logins
-device_data = session.auth.get_device_data()
+device_data = session.get_device_data()
 print(device_data)
 
 session.startSession()

--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -22,8 +22,8 @@ if login.get("ChallengeName") == SMS_REQUIRED:
     session.sms2fa(code, login)
 
 # Device data is need for future device logins
-deviceData = session.auth.getDeviceData()
-print(deviceData)
+device_data = session.auth.get_device_data()
+print(device_data)
 
 session.startSession()
 ```
@@ -34,14 +34,14 @@ Below is an example of how to log in to Hive using device authentication, to cre
 
 
 ```Python
-from pyhiveapi import Hive, SMS_REQUIRED
+from pyhiveapi import Hive, Auth as HiveAuth, SMS_REQUIRED
 
-session = Hive(
+session = HiveAuth(
     username="<Hive Username>",
     password="<Hive Password>",
-    deviceGroupKey="<Hive Device Group Key>",
-    deviceKey="<Hive Device Key>",
-    devicePassword="<Hive Device Password>",
+    device_group_key="<Hive Device Group Key>",
+    device_key="<Hive Device Key>",
+    device_password="<Hive Device Password>",
 )
 session.deviceLogin()
 session.startSession()


### PR DESCRIPTION
I believe these updates are correct, although I'm currently unable to get device-login working myself.  However, having these example documents being out-of-date to the current library caused some extra headaches.