### PR TITLE
Update api.md to better match library 0.5.15

### DIFF
--- a/docs/examples/api.md
+++ b/docs/examples/api.md
@@ -16,14 +16,18 @@ import pyhiveapi as Hive
 
 tokens = {}
 hive_auth = Hive.Auth(username="<Hive Username>", password="<Hive Password>")
-authData = hive_auth.login()
+auth_data = hive_auth.login()
 
-if authData.get("ChallengeName") == "SMS_MFA":
+if auth_data.get("ChallengeName") == Hive.SMS_REQUIRED:
     code = input("Enter your 2FA code: ")
-    authData = hive_auth.sms_2fa(code, authData)
+    auth_data = hive_auth.sms_2fa(code, auth_data)
+    hive_auth.device_registration('MyPyHiveAPIDevice')
+    print(f"device_group_key: {hive_auth.device_group_key}")
+    print(f"device_key: {hive_auth.device_key}")
+    print(f"device_password: {hive_auth.device_password}")
 
-if "AuthenticationResult" in authData:
-    session = authData["AuthenticationResult"]
+if "AuthenticationResult" in auth_data:
+    session = auth_data["AuthenticationResult"]
     tokens.update({"token": session["IdToken"]})
     tokens.update({"refreshToken": session["RefreshToken"]})
     tokens.update({"accessToken": session["AccessToken"]})
@@ -44,12 +48,11 @@ hive_auth = Hive.Auth(<Hive Username>", "<Hive Password>", "Hive Device Group Ke
 auth_data = hive_auth.device_login()
 
 if "AuthenticationResult" in auth_data:
-    session = auth_data["AuthenticationResult"]
+    auth_result = session["AuthenticationResult"]
     tokens.update({"token": session["IdToken"]})
     tokens.update({"refreshToken": session["RefreshToken"]})
     tokens.update({"accessToken": session["AccessToken"]})
 ```
-
 
 
 ## Refresh Tokens
@@ -78,6 +81,6 @@ Below is an example how to data from the Hive platform
 using the session token acquired from login.
 
 ```Python
-api = Hive.API(token=tokens["IdToken"])
+api = Hive.API(token=tokens["token"])
 data = api.getAll()
 ```

--- a/docs/examples/api.md
+++ b/docs/examples/api.md
@@ -15,7 +15,7 @@ and get a session token.
 import pyhiveapi as Hive
 
 tokens = {}
-hive_auth = Hive.Auth("<Hive Username>", "<Hive Password>")
+hive_auth = Hive.Auth(username="<Hive Username>", password="<Hive Password>")
 authData = hive_auth.login()
 
 if authData.get("ChallengeName") == "SMS_MFA":
@@ -41,10 +41,10 @@ import pyhiveapi as Hive
 
 tokens = {}
 hive_auth = Hive.Auth(<Hive Username>", "<Hive Password>", "Hive Device Group Key>", "<Hive Device Key>", "<Hive Device Password>")
-authData = hive_auth.deviceLogin()
+auth_data = hive_auth.device_login()
 
-if "AuthenticationResult" in authData:
-    session = authData["AuthenticationResult"]
+if "AuthenticationResult" in auth_data:
+    session = auth_data["AuthenticationResult"]
     tokens.update({"token": session["IdToken"]})
     tokens.update({"refreshToken": session["RefreshToken"]})
     tokens.update({"accessToken": session["AccessToken"]})
@@ -62,11 +62,11 @@ import pyhiveapi as Hive
 
 tokens = {}
 hive_auth = Hive.Auth(<Hive Username>", "<Hive Password>", "Hive Device Group Key>", "<Hive Device Key>", "<Hive Device Password>")
-authData = hive_auth.deviceLogin()
-newTokens = hive_auth.refreshToken(tokens['AuthenticationResult']['RefreshToken'])
+auth_data = hive_auth.device_login()
+new_tokens = hive_auth.refresh_token(tokens['AuthenticationResult']['RefreshToken'])
 
-if "AuthenticationResult" in newTokens:
-    session = newTokens["AuthenticationResult"]
+if "AuthenticationResult" in new_tokens:
+    session = new_tokens["AuthenticationResult"]
     tokens.update({"token": session["IdToken"]})
     tokens.update({"refreshToken": session["RefreshToken"]})
     tokens.update({"accessToken": session["AccessToken"]})
@@ -78,6 +78,6 @@ Below is an example how to data from the Hive platform
 using the session token acquired from login.
 
 ```Python
-api = Hive.HiveApi(token=tokens["IdToken"])
+api = Hive.API(token=tokens["IdToken"])
 data = api.getAll()
 ```

--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -22,7 +22,7 @@ if login.get("ChallengeName") == SMS_REQUIRED:
     session.sms2fa(code, login)
 
 # Device data is need for future device logins
-device_data = session.auth.get_device_data()
+device_data = session.get_device_data()
 print(device_data)
 
 session.startSession()

--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -22,8 +22,8 @@ if login.get("ChallengeName") == SMS_REQUIRED:
     session.sms2fa(code, login)
 
 # Device data is need for future device logins
-deviceData = session.auth.getDeviceData()
-print(deviceData)
+device_data = session.auth.get_device_data()
+print(device_data)
 
 session.startSession()
 ```
@@ -34,14 +34,14 @@ Below is an example of how to log in to Hive using device authentication, to cre
 
 
 ```Python
-from pyhiveapi import Hive, SMS_REQUIRED
+from pyhiveapi import Hive, Auth as HiveAuth, SMS_REQUIRED
 
-session = Hive(
+session = HiveAuth(
     username="<Hive Username>",
     password="<Hive Password>",
-    deviceGroupKey="<Hive Device Group Key>",
-    deviceKey="<Hive Device Key>",
-    devicePassword="<Hive Device Password>",
+    device_group_key="<Hive Device Group Key>",
+    device_key="<Hive Device Key>",
+    device_password="<Hive Device Password>",
 )
 session.deviceLogin()
 session.startSession()

--- a/docs/examples/session.md
+++ b/docs/examples/session.md
@@ -22,8 +22,8 @@ if login.get("ChallengeName") == SMS_REQUIRED:
     session.sms2fa(code, login)
 
 # Device data is need for future device logins
-device_data = session.get_device_data()
-print(device_data)
+deviceData = session.auth.getDeviceData()
+print(deviceData)
 
 session.startSession()
 ```
@@ -34,14 +34,14 @@ Below is an example of how to log in to Hive using device authentication, to cre
 
 
 ```Python
-from pyhiveapi import Hive, Auth as HiveAuth, SMS_REQUIRED
+from pyhiveapi import Hive, SMS_REQUIRED
 
-session = HiveAuth(
+session = Hive(
     username="<Hive Username>",
     password="<Hive Password>",
-    device_group_key="<Hive Device Group Key>",
-    device_key="<Hive Device Key>",
-    device_password="<Hive Device Password>",
+    deviceGroupKey="<Hive Device Group Key>",
+    deviceKey="<Hive Device Key>",
+    devicePassword="<Hive Device Password>",
 )
 session.deviceLogin()
 session.startSession()


### PR DESCRIPTION
session.md is definitely out of date (and contradicts api.md), but I don't know the library well enough to update that page.  I originally tried to update that page but gave up and reverted.

api.md should now reflect the changes to the library to better match 0.5.1
e.g. .deviceLogin() becomes .device_login(), etc.

I've added possibly the most important but previously missing step - the call to .device_registration().  Thanks to [this comment](https://github.com/Pyhass/Pyhiveapi/issues/57#issue-1502035298) for pointing me in the right direction!

I've also changed some of the variable names to be snake_case rather than camelCase to match similar changes in the library method and variable names.